### PR TITLE
Add preference widget for status display type

### DIFF
--- a/src/audacious-discord-rpc.cpp
+++ b/src/audacious-discord-rpc.cpp
@@ -41,9 +41,12 @@ const char RPCPlugin::about[]
       "(Discord should be running before this plugin is loaded.)";
 
 static const ComboItem status_display_items[]
-    = {ComboItem(N_("Application"), static_cast<int>(discord::StatusDisplayType::Name)),
-       ComboItem(N_("Track title"), static_cast<int>(discord::StatusDisplayType::Details)),
-       ComboItem(N_("Track artist"), static_cast<int>(discord::StatusDisplayType::State))};
+    = {ComboItem(N_("Music player"),
+                 static_cast<int>(discord::StatusDisplayType::Name)),
+       ComboItem(N_("Song title"),
+                 static_cast<int>(discord::StatusDisplayType::Details)),
+       ComboItem(N_("Artist name"),
+                 static_cast<int>(discord::StatusDisplayType::State))};
 
 const PreferencesWidget RPCPlugin::widgets[] = {
 #if (!(defined(DISABLE_RPC_CAF)) && !(DISABLE_RPC_CAF))
@@ -52,17 +55,20 @@ const PreferencesWidget RPCPlugin::widgets[] = {
 #endif
     WidgetCheck(N_("Hide presence when paused"),
                 WidgetBool(PLUGIN_ID, "hide_when_paused")),
-    WidgetCombo(N_("Status display:"),
+    WidgetCombo(N_("Status display"),
                 WidgetInt(PLUGIN_ID, "status_display_type"),
                 {{status_display_items}, nullptr}),
     WidgetButton(N_("Show on GitHub"), {open_github, nullptr})};
 
 const char *const RPCPlugin::defaults[] = {
 #if (!(defined(DISABLE_RPC_CAF)) && !(DISABLE_RPC_CAF))
-    "fetch_covers", "FALSE",
+    "fetch_covers",
+    "FALSE",
 #endif
-    "hide_when_paused", "FALSE",
-    "status_display_type", int_to_str(static_cast<int>(discord::StatusDisplayType::Name)),
+    "hide_when_paused",
+    "FALSE",
+    "status_display_type",
+    int_to_str(static_cast<int>(discord::StatusDisplayType::Name)),
     nullptr};
 
 const PluginPreferences RPCPlugin::prefs
@@ -159,7 +165,8 @@ void playback_to_presence() {
 
      presence.setLargeImageKey("logo")
          .setActivityType(discord::ActivityType::Listening)
-         .setStatusDisplayType(static_cast<discord::StatusDisplayType>(status_display_type))
+         .setStatusDisplayType(
+             static_cast<discord::StatusDisplayType>(status_display_type))
          .setDetails((const char *)title)
          .setState((const char *)artist)
          .setLargeImageText(has_album ? (const char *)album : "")

--- a/src/audacious-discord-rpc.cpp
+++ b/src/audacious-discord-rpc.cpp
@@ -40,10 +40,10 @@ const char RPCPlugin::about[]
       "Displays the current playing track as your Discord status.\n"
       "(Discord should be running before this plugin is loaded.)";
 
-static const ComboItem statusDisplayItems[]
+static const ComboItem status_display_items[]
     = {ComboItem(N_("Application"), static_cast<int>(discord::StatusDisplayType::Name)),
-       ComboItem(N_("Title"), static_cast<int>(discord::StatusDisplayType::Details)),
-       ComboItem(N_("Artist"), static_cast<int>(discord::StatusDisplayType::State))};
+       ComboItem(N_("Track title"), static_cast<int>(discord::StatusDisplayType::Details)),
+       ComboItem(N_("Track artist"), static_cast<int>(discord::StatusDisplayType::State))};
 
 const PreferencesWidget RPCPlugin::widgets[] = {
 #if (!(defined(DISABLE_RPC_CAF)) && !(DISABLE_RPC_CAF))
@@ -54,7 +54,7 @@ const PreferencesWidget RPCPlugin::widgets[] = {
                 WidgetBool(PLUGIN_ID, "hide_when_paused")),
     WidgetCombo(N_("Status display:"),
                 WidgetInt(PLUGIN_ID, "status_display_type"),
-                {{statusDisplayItems}}),
+                {{status_display_items}, nullptr}),
     WidgetButton(N_("Show on GitHub"), {open_github, nullptr})};
 
 const char *const RPCPlugin::defaults[] = {
@@ -62,7 +62,7 @@ const char *const RPCPlugin::defaults[] = {
     "fetch_covers", "FALSE",
 #endif
     "hide_when_paused", "FALSE",
-    "status_display_type", std::to_string(static_cast<int>(discord::StatusDisplayType::Name)).c_str(),
+    "status_display_type", int_to_str(static_cast<int>(discord::StatusDisplayType::Name)),
     nullptr};
 
 const PluginPreferences RPCPlugin::prefs


### PR DESCRIPTION
Allows the user to select what to display in the Discord status: "Audacious" (the default, current behaviour), the title, or the artist.

Due to issue #5, I only got this to build with `-Wno-unused-result -Wno-missing-field-initializers`.

Changes are very much appreciated as this was made as a quick proof of concept rather than a fleshed-out solution.